### PR TITLE
Added metadatablock schema export

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,3 +65,10 @@ def dataverse_base_class():
         bar: str
 
     return Test
+
+
+@pytest.fixture
+def metadatablock_json_schema():
+    """Sets up a metadatablock json schema"""
+
+    return open("./tests/fixtures/dataversebase/toydataset.schema.json").read()

--- a/tests/core/test_dataverse_base.py
+++ b/tests/core/test_dataverse_base.py
@@ -1,3 +1,10 @@
+import importlib
+import sys
+import json
+
+from easyDataverse.tools.codegen.generator import generate_python_api
+
+
 class TestDataverseBase:
     def test_from_json_string(self, dataverse_base_class):
         """Tests whether the init from a JSON string works"""
@@ -62,3 +69,33 @@ class TestDataverseBase:
         assert (
             test_class.from_yaml_file(yaml_in) == expected
         ), "YAML file init does not work properly"
+
+    def test_json_schema_export(self, metadatablock_json_schema):
+        """Tests whether the given metadatablock schema export is correct"""
+
+        def _get_module(name: str, loc: str):
+            """Fetches a module from a loc"""
+
+            spec = importlib.util.spec_from_file_location(name, loc)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[name] = module
+            spec.loader.exec_module(module)
+
+            return module
+
+        # Generate the API
+        generate_python_api(
+            path="./tests/fixtures/blocks",
+            out="./tests/generator_test",
+            name="pySomeTest",
+        )
+
+        # Import the metadatablock
+        block = _get_module(
+            "toyDataset",
+            "./tests/generator_test/pySomeTest/pySomeTest/metadatablocks/toyDataset.py",
+        )
+
+        assert json.loads(block.ToyDataset.json_schema()) == json.loads(
+            metadatablock_json_schema
+        ), f"Metadatablock JSON schema is wrong."

--- a/tests/fixtures/dataversebase/toydataset.schema.json
+++ b/tests/fixtures/dataversebase/toydataset.schema.json
@@ -1,0 +1,59 @@
+{
+    "title": "ToyDataset",
+    "type": "object",
+    "properties": {
+      "compound": {
+        "title": "Compound",
+        "description": "Some compound field",
+        "multiple": false,
+        "typeClass": "compound",
+        "typeName": "fooCompound",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Compound"
+        }
+      },
+      "foo": {
+        "title": "Foo",
+        "description": "Some primitive field",
+        "multiple": false,
+        "typeClass": "primitive",
+        "typeName": "fooField",
+        "type": "string"
+      },
+      "some_enum": {
+        "description": "Some enum field",
+        "multiple": false,
+        "typeClass": "controlledVocabulary",
+        "typeName": "fooEnum",
+        "allOf": [
+          {
+            "$ref": "#/definitions/SomeEnum"
+          }
+        ]
+      }
+    },
+    "definitions": {
+      "Compound": {
+        "title": "Compound",
+        "type": "object",
+        "properties": {
+          "bar": {
+            "title": "Bar",
+            "description": "Another primitive field",
+            "multiple": false,
+            "typeClass": "primitive",
+            "typeName": "fooCompoundField",
+            "type": "string"
+          }
+        }
+      },
+      "SomeEnum": {
+        "title": "SomeEnum",
+        "description": "Some enum field",
+        "enum": [
+          "enum"
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
Added JSON schema export for metadata blocks which includes the internal Dataverse schema (`multiple`, `typeClass` etc.) as issued in #1 . The method can be used on any generated metadata block code by

```python
# Returns schema as a string
dataset.citation.json_schema()

# Writes schema to a 'path/[BLOCKNAME].schema.json' file
dataset.citation.json_schema(path="path/")
```

Closes #1 