### PR TITLE
Use `editMetadata` endpoint for dataset updates

### DIFF
--- a/easyDataverse/base.py
+++ b/easyDataverse/base.py
@@ -194,7 +194,7 @@ class DataverseBase(BaseModel):
             if self._is_compound(field) and self._is_multiple(field):
                 value = self._process_multiple_compound(getattr(self, name))
             elif self._is_compound(field):
-                value = getattr(self, name).extract_changed()
+                value = self._process_single_compound(getattr(self, name))
             else:
                 value = getattr(self, name)
 
@@ -226,11 +226,13 @@ class DataverseBase(BaseModel):
 
         return [compound.dataverse_dict() for compound in compounds]
 
-    @staticmethod
-    def _change_to_dict(compound: List[Dict]) -> Dict[str, Dict]:
-        """Converts a list of changed compounds to a dictionary"""
+    def _process_single_compound(self, compound) -> Dict:
+        """Processes a single compound"""
 
-        return {field["typeName"]: field for field in compound}
+        if not compound._changed:
+            return {}
+
+        return compound.dataverse_dict()
 
     def _is_compound(self, field_info: FieldInfo):
         """Checks whether a field is a compound"""

--- a/easyDataverse/classgen.py
+++ b/easyDataverse/classgen.py
@@ -363,6 +363,9 @@ def union_type(dtypes: Tuple):
         Union: A Union typing encapsulating the given types
     """
 
+    if not isinstance(dtypes, tuple):
+        raise TypeError(f"Expected a tuple of types, got {type(dtypes)}")
+
     if len(dtypes) < 2:
         raise ValueError(f"Union type requires more than a single type")
 

--- a/easyDataverse/dataset.py
+++ b/easyDataverse/dataset.py
@@ -221,26 +221,24 @@ class Dataset(BaseModel):
         return self.p_id
 
     def update(self):
-        """Updates a given dataset if a p_id has been given.
+        """Updates a dataset if a p_id has been given."""
 
-        Use this function in conjunction with 'from_dataverse_doi' to edit and update datasets.
-        Due to the Dataverse REST API, downloaded datasets wont include contact mails, but in
-        order to update the dataset it is required. For this, provide a name and mail for contact.
-        EasyDataverse will search existing contacts and when a name fits, it will add the mail.
-        Otherwise a new contact is added to the dataset.
-
-        Args:
-            contact_name (str, optional): Name of the contact. Defaults to None.
-            contact_mail (str, optional): Mail of the contact. Defaults to None.
-        """
-        self._validate_required_fields()
         update_dataset(
-            json_data=self.dataverse_dict()["datasetVersion"],
+            to_change=self._extract_changes(),
             p_id=self.p_id,  # type: ignore
             files=self.files,
             DATAVERSE_URL=str(self.DATAVERSE_URL),  # type: ignore
             API_TOKEN=str(self.API_TOKEN),
         )
+
+    def _extract_changes(self) -> Dict:
+        """Extracts the changes that have been made to the dataset."""
+
+        changes = []
+        for block in self.metadatablocks.values():
+            changes += block.extract_changed()
+
+        return {"fields": changes}
 
     # ! Validation
     def _validate_required_fields(self):


### PR DESCRIPTION
**Overview**

This PR changes the endpoint usage for the `update`-method to use the `editMetadata` endpoint instead of a complete metadata reset. This way, only the actual changes are pushed while keeping those that have not changed untouched. Due to the functionality of `editMetadata`, multiple compounds need to be updated completely once a single one has changed.

**TLDR**

* Switched endpoint for metadata updates