### PR TITLE
Allow different filename upon file upload

### DIFF
--- a/easyDataverse/classgen.py
+++ b/easyDataverse/classgen.py
@@ -363,6 +363,9 @@ def union_type(dtypes: Tuple):
         Union: A Union typing encapsulating the given types
     """
 
+    if not isinstance(dtypes, tuple):
+        raise TypeError(f"Expected a tuple of types, got {type(dtypes)}")
+
     if len(dtypes) < 2:
         raise ValueError(f"Union type requires more than a single type")
 

--- a/easyDataverse/dataset.py
+++ b/easyDataverse/dataset.py
@@ -65,6 +65,7 @@ class Dataset(BaseModel):
         self,
         local_path: str,
         dv_dir: str = "",
+        file_name: Optional[str] = None,
         categories: List[str] = ["DATA"],
         description: str = "",
     ):
@@ -73,6 +74,7 @@ class Dataset(BaseModel):
         Args:
             local_path (str): Path to the file.
             dv_dir (str, optional): Directory in which the file should be stored in Dataverse. Defaults to "".
+            file_name (str, optional): Name of the file in Dataverse. Defaults to None, which will use the basename of local_path.
             categories (List[str], optional): List of categories to assign to the file. Defaults to ["DATA"].
             description (str, optional): Description of the file. Defaults to "".
 
@@ -85,6 +87,7 @@ class Dataset(BaseModel):
             directoryLabel=dv_dir,
             description=description,
             categories=categories,
+            file_name=file_name,  # type: ignore
         )
 
         if file not in self.files:


### PR DESCRIPTION
This PR aligns to the recent `python-dvuploader` release, where it is possible to pass a different display name for a file.

**Example**

```python
dataverse = Dataverse(BASE_URL, API_TOKEN)
dataset = dataverse.load_dataset(PID)

dataset.add_file(local_path="original.txt", filename="something_different.txt")
```

The file will be uploaded as `something_different.txt` instead of `original.txt`