### PR TITLE
Fix date fields not accepting years

### DIFF
--- a/easyDataverse/classgen.py
+++ b/easyDataverse/classgen.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 import forge
 import types
 import re
@@ -17,7 +17,7 @@ TYPE_MAPPING = {
     "integer": int,
     "int": int,
     "textbox": str,
-    "date": date,
+    "date": str,
     "email": EmailStr,
 }
 

--- a/easyDataverse/classgen.py
+++ b/easyDataverse/classgen.py
@@ -1,4 +1,3 @@
-from datetime import date, datetime
 import forge
 import types
 import re

--- a/tests/fixtures/minimal_upload.json
+++ b/tests/fixtures/minimal_upload.json
@@ -1,75 +1,79 @@
 {
-    "datasetVersion": {
-        "metadataBlocks": {
-            "citation": {
-                "fields": [
-                    {
-                        "multiple": true,
-                        "typeClass": "compound",
-                        "typeName": "author",
-                        "value": [
-                            {
-                                "authorName": {
-                                    "multiple": false,
-                                    "typeClass": "primitive",
-                                    "typeName": "authorName",
-                                    "value": "John Doe"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "multiple": true,
-                        "typeClass": "compound",
-                        "typeName": "datasetContact",
-                        "value": [
-                            {
-                                "datasetContactName": {
-                                    "multiple": false,
-                                    "typeClass": "primitive",
-                                    "typeName": "datasetContactName",
-                                    "value": "John Doe"
-                                },
-                                "datasetContactEmail": {
-                                    "multiple": false,
-                                    "typeClass": "primitive",
-                                    "typeName": "datasetContactEmail",
-                                    "value": "john@doe.com"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "multiple": true,
-                        "typeClass": "compound",
-                        "typeName": "dsDescription",
-                        "value": [
-                            {
-                                "dsDescriptionValue": {
-                                    "multiple": false,
-                                    "typeClass": "primitive",
-                                    "typeName": "dsDescriptionValue",
-                                    "value": "This is a description of the dataset"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "multiple": true,
-                        "typeClass": "controlledVocabulary",
-                        "typeName": "subject",
-                        "value": [
-                            "Other"
-                        ]
-                    },
-                    {
-                        "multiple": false,
-                        "typeClass": "primitive",
-                        "typeName": "title",
-                        "value": "My dataset"
-                    }
-                ]
-            }
-        }
+  "datasetVersion": {
+    "metadataBlocks": {
+      "citation": {
+        "fields": [
+          {
+            "multiple": true,
+            "typeClass": "compound",
+            "typeName": "author",
+            "value": [
+              {
+                "authorName": {
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "typeName": "authorName",
+                  "value": "John Doe"
+                }
+              }
+            ]
+          },
+          {
+            "multiple": true,
+            "typeClass": "compound",
+            "typeName": "datasetContact",
+            "value": [
+              {
+                "datasetContactName": {
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "typeName": "datasetContactName",
+                  "value": "John Doe"
+                },
+                "datasetContactEmail": {
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "typeName": "datasetContactEmail",
+                  "value": "john@doe.com"
+                }
+              }
+            ]
+          },
+          {
+            "multiple": true,
+            "typeClass": "compound",
+            "typeName": "dsDescription",
+            "value": [
+              {
+                "dsDescriptionValue": {
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "typeName": "dsDescriptionValue",
+                  "value": "This is a description of the dataset"
+                },
+                "dsDescriptionDate": {
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "typeName": "dsDescriptionDate",
+                  "value": "2024"
+                }
+              }
+            ]
+          },
+          {
+            "multiple": true,
+            "typeClass": "controlledVocabulary",
+            "typeName": "subject",
+            "value": ["Other"]
+          },
+          {
+            "multiple": false,
+            "typeClass": "primitive",
+            "typeName": "title",
+            "value": "My dataset"
+          }
+        ]
+      }
     }
+  }
 }

--- a/tests/integration/test_dataset_creation.py
+++ b/tests/integration/test_dataset_creation.py
@@ -25,7 +25,8 @@ class TestDatasetCreation:
         dataset.citation.subject = ["Other"]
         dataset.citation.add_author(name="John Doe")
         dataset.citation.add_ds_description(
-            value="This is a description of the dataset"
+            value="This is a description of the dataset",
+            date="2024",
         )
         dataset.citation.add_dataset_contact(
             name="John Doe",


### PR DESCRIPTION
**Overview**

This pull request addresses the validation errors that occur when only the year is entered in a 'date' field. As there is no direct alternative that accommodates both year and complete dates, this pull request modifies the expected data type from 'date' to 'str' and delegates the validation of the actual string to Dataverse.


**TLDR**

* Fix years not possible to add
* Added test to check functionality