### PR TITLE
Fix `update` not adding multiple compounds

### DIFF
--- a/easyDataverse/base.py
+++ b/easyDataverse/base.py
@@ -25,6 +25,7 @@ class DataverseBase(BaseModel):
     )
 
     _changed: Set = PrivateAttr(default_factory=set)
+    _new: bool = PrivateAttr(default=True)
 
     # ! Overloads
     def __setattr__(self, name: str, value: Any) -> None:
@@ -184,9 +185,9 @@ class DataverseBase(BaseModel):
     def extract_changed(self) -> List[Dict]:
         """Extracts the changed fields from the object"""
 
-        self._add_changed_multiples()
-
         changed_fields = []
+
+        self._add_changed_multiples()
 
         for name in self._changed:
             field = self.model_fields[name]
@@ -212,10 +213,17 @@ class DataverseBase(BaseModel):
             if not self._is_multiple(field):
                 continue
 
-            self._changed.add(name)
+            has_changed = any(
+                compound._changed or compound._new
+                for compound in getattr(self, name)
+            )
+
+            if has_changed:
+                self._changed.add(name)
 
     def _process_multiple_compound(self, compounds) -> List[Dict]:
         """Processes multiple compounds"""
+
         return [compound.dataverse_dict() for compound in compounds]
 
     def _process_single_compound(self, compound) -> Dict:
@@ -245,6 +253,21 @@ class DataverseBase(BaseModel):
             "typeName": field.json_schema_extra["typeName"],  # type: ignore
             "value": value,
         }
+
+    def _set_new_prop(self, value: bool):
+        """Sets the new property of the object"""
+
+        self._new = value
+
+        for attr, field in self.model_fields.items():
+            if not field.json_schema_extra["typeClass"] == "compound":
+                continue
+
+            if field.json_schema_extra["multiple"]:
+                for compound in getattr(self, attr):
+                    compound._set_new_prop(value)
+            else:
+                getattr(self, attr)._set_new_prop(value)
 
     @staticmethod
     def is_empty(value):

--- a/easyDataverse/base.py
+++ b/easyDataverse/base.py
@@ -212,18 +212,10 @@ class DataverseBase(BaseModel):
             if not self._is_multiple(field):
                 continue
 
-            value = getattr(self, name)
-            has_changes = any(value._changed for value in value)
-
-            if has_changes:
-                self._changed.add(name)
+            self._changed.add(name)
 
     def _process_multiple_compound(self, compounds) -> List[Dict]:
-        """Whenever a single compound has changed, return all compounds."""
-
-        if not any(len(compound._changed) for compound in compounds):
-            return []
-
+        """Processes multiple compounds"""
         return [compound.dataverse_dict() for compound in compounds]
 
     def _process_single_compound(self, compound) -> Dict:

--- a/easyDataverse/dataset.py
+++ b/easyDataverse/dataset.py
@@ -225,10 +225,16 @@ class Dataset(BaseModel):
 
         return self.p_id
 
-    def update(self):
+    def update(self, replace: bool = True):
         """Updates a dataset if a p_id has been given.
 
         Use this function to update a dataset that has already been uploaded to Dataverse.
+
+        Args:
+            replace (bool, optional): Whether to replace the dataset or not. Defaults to True.
+
+        Raises:
+            HTTPError: If the dataset could not be updated.
         """
 
         if not self.p_id:
@@ -238,6 +244,7 @@ class Dataset(BaseModel):
             to_change=self._extract_changes(),
             p_id=self.p_id,  # type: ignore
             files=self.files,
+            replace=replace,
             DATAVERSE_URL=str(self.DATAVERSE_URL),  # type: ignore
             API_TOKEN=str(self.API_TOKEN),
         )

--- a/easyDataverse/dataverse.py
+++ b/easyDataverse/dataverse.py
@@ -339,6 +339,10 @@ class Dataverse(BaseModel):
                 n_parallel_downloads=n_parallel_downloads,
             )
 
+        # Set "new" prop to False
+        for metadatablock in dataset.metadatablocks.values():
+            metadatablock._set_new_prop(False)
+
         return dataset
 
     def _fetch_dataset(

--- a/easyDataverse/uploader.py
+++ b/easyDataverse/uploader.py
@@ -172,13 +172,10 @@ def _update_metadata(
         requests.HTTPError: If the request fails.
     """
 
-    if replace:
-        EDIT_ENDPOINT = f"{base_url.rstrip('/')}/api/datasets/:persistentId/editMetadata?persistentId={p_id}&replace=true"
-    else:
-        EDIT_ENDPOINT = f"{base_url.rstrip('/')}/api/datasets/:persistentId/editMetadata?persistentId={p_id}&replace=false"
-
     headers = {"X-Dataverse-key": api_token}
-    response = requests.put(EDIT_ENDPOINT, headers=headers, json=to_change)
+    endpoint = f"/api/datasets/:persistentId/editMetadata?persistentId={p_id}&replace={str(replace).lower()}"
+    url = urljoin(base_url, endpoint)
+    response = requests.put(url, headers=headers, json=to_change)
 
     if response.status_code != 200:
         raise requests.HTTPError(f"Failed to update metadata: {response.text}")

--- a/easyDataverse/uploader.py
+++ b/easyDataverse/uploader.py
@@ -175,7 +175,7 @@ def _update_metadata(
     if replace:
         EDIT_ENDPOINT = f"{base_url.rstrip('/')}/api/datasets/:persistentId/editMetadata?persistentId={p_id}&replace=true"
     else:
-        EDIT_ENDPOINT = f"{base_url.rstrip('/')}/api/datasets/:persistentId/editMetadata?persistentId={p_id}"
+        EDIT_ENDPOINT = f"{base_url.rstrip('/')}/api/datasets/:persistentId/editMetadata?persistentId={p_id}&replace=false"
 
     headers = {"X-Dataverse-key": api_token}
     response = requests.put(EDIT_ENDPOINT, headers=headers, json=to_change)

--- a/tests/integration/test_dataset_update.py
+++ b/tests/integration/test_dataset_update.py
@@ -2,7 +2,6 @@ from typing import Dict
 
 import pytest
 import requests
-from requests.models import HTTPError
 
 from easyDataverse import Dataverse
 

--- a/tests/integration/test_dataset_update.py
+++ b/tests/integration/test_dataset_update.py
@@ -163,8 +163,9 @@ class TestDatasetUpdate:
             other_id_fields[1]["otherIdAgency"]["value"] == "Software Heritage2"
         ), "The updated dataset does not have the expected other id agency."
 
+
     @pytest.mark.integration
-    def test_dataset_update_invalid(
+    def test_update_edit(
         self,
         credentials,
         minimal_upload,
@@ -194,10 +195,53 @@ class TestDatasetUpdate:
         dataset = dataverse.load_dataset(pid)
 
         # Check if multiple compound changes are tracked too
-        dataset.citation.title = "Title has changed"
+        dataset.citation.add_other_id(agency="Software Heritage1", value="softwareid1")
+        dataset.citation.add_other_id(agency="Software Heritage2", value="softwareid2")
 
-        with pytest.raises(HTTPError):
-            dataset.update(replace=False)
+        dataset.update(replace=False)
+
+        # Fetch another time and edit the first entry
+        dataset = dataverse.load_dataset(pid)
+        dataset.citation.other_id[0].agency = "Software Heritage1 updated"
+
+        dataset.update(replace=False)
+
+        # Re-fetch the dataset
+        url = (
+            f"{base_url}/api/datasets/:persistentId/versions/:draft?persistentId={pid}"
+        )
+
+        response = requests.get(
+            url,
+            headers={"X-Dataverse-key": api_token},
+        )
+
+        response.raise_for_status()
+        updated_dataset = response.json()
+        other_id_fields = next(
+            filter(
+                lambda x: x["typeName"] == "otherId",
+                updated_dataset["data"]["metadataBlocks"]["citation"]["fields"],
+            )
+        )["value"]
+
+        # Assert
+        assert (
+            len(other_id_fields) == 2
+        ), "The updated dataset does not have the expected number of other ids."
+        assert (
+            other_id_fields[0]["otherIdValue"]["value"] == "softwareid1"
+        ), "The updated dataset does not have the expected other id."
+        assert (
+            other_id_fields[1]["otherIdValue"]["value"] == "softwareid2"
+        ), "The updated dataset does not have the expected other id."
+        assert (
+            other_id_fields[0]["otherIdAgency"]["value"] == "Software Heritage1 updated"
+        ), "The updated dataset does not have the expected other id agency."
+        assert (
+            other_id_fields[1]["otherIdAgency"]["value"] == "Software Heritage2"
+        ), "The updated dataset does not have the expected other id agency."
+
 
     @staticmethod
     def sort_citation(dataset: Dict):

--- a/tests/integration/test_dataset_update.py
+++ b/tests/integration/test_dataset_update.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 import pytest
 import requests
+from requests.models import HTTPError
 
 from easyDataverse import Dataverse
 
@@ -89,6 +90,114 @@ class TestDatasetUpdate:
         assert (
             other_id_fields[1]["otherIdAgency"]["value"] == "Software Heritage2"
         ), "The updated dataset does not have the expected other id agency."
+
+    @pytest.mark.integration
+    def test_dataset_update_wo_replace(
+        self,
+        credentials,
+        minimal_upload,
+    ):
+        # Arrange
+        base_url, api_token = credentials
+        url = f"{base_url}/api/dataverses/root/datasets"
+        response = requests.post(
+            url=url,
+            json=minimal_upload,
+            headers={
+                "X-Dataverse-key": api_token,
+                "Content-Type": "application/json",
+            },
+        )
+
+        response.raise_for_status()
+        pid = response.json()["data"]["persistentId"]
+
+        # Act
+        dataverse = Dataverse(
+            server_url=base_url,
+            api_token=api_token,
+        )
+
+        # Fetch the dataset and update the title
+        dataset = dataverse.load_dataset(pid)
+
+        # Check if multiple compound changes are tracked too
+        dataset.citation.add_other_id(agency="Software Heritage1", value="softwareid1")
+        dataset.citation.add_other_id(agency="Software Heritage2", value="softwareid2")
+
+        dataset.update(replace=False)
+
+        # Re-fetch the dataset
+        url = (
+            f"{base_url}/api/datasets/:persistentId/versions/:draft?persistentId={pid}"
+        )
+
+        response = requests.get(
+            url,
+            headers={"X-Dataverse-key": api_token},
+        )
+
+        response.raise_for_status()
+        updated_dataset = response.json()
+        other_id_fields = next(
+            filter(
+                lambda x: x["typeName"] == "otherId",
+                updated_dataset["data"]["metadataBlocks"]["citation"]["fields"],
+            )
+        )["value"]
+
+        # Assert
+        assert (
+            len(other_id_fields) == 2
+        ), "The updated dataset does not have the expected number of other ids."
+        assert (
+            other_id_fields[0]["otherIdValue"]["value"] == "softwareid1"
+        ), "The updated dataset does not have the expected other id."
+        assert (
+            other_id_fields[1]["otherIdValue"]["value"] == "softwareid2"
+        ), "The updated dataset does not have the expected other id."
+        assert (
+            other_id_fields[0]["otherIdAgency"]["value"] == "Software Heritage1"
+        ), "The updated dataset does not have the expected other id agency."
+        assert (
+            other_id_fields[1]["otherIdAgency"]["value"] == "Software Heritage2"
+        ), "The updated dataset does not have the expected other id agency."
+
+    @pytest.mark.integration
+    def test_dataset_update_invalid(
+        self,
+        credentials,
+        minimal_upload,
+    ):
+        # Arrange
+        base_url, api_token = credentials
+        url = f"{base_url}/api/dataverses/root/datasets"
+        response = requests.post(
+            url=url,
+            json=minimal_upload,
+            headers={
+                "X-Dataverse-key": api_token,
+                "Content-Type": "application/json",
+            },
+        )
+
+        response.raise_for_status()
+        pid = response.json()["data"]["persistentId"]
+
+        # Act
+        dataverse = Dataverse(
+            server_url=base_url,
+            api_token=api_token,
+        )
+
+        # Fetch the dataset and update the title
+        dataset = dataverse.load_dataset(pid)
+
+        # Check if multiple compound changes are tracked too
+        dataset.citation.title = "Title has changed"
+
+        with pytest.raises(HTTPError):
+            dataset.update(replace=False)
 
     @staticmethod
     def sort_citation(dataset: Dict):


### PR DESCRIPTION
**Overview**

This pull request resolves the issue where the update method fails to properly update multiple added compounds. With this pull request, newly added lists of compounds are now directly included. Additionally, a test case has been added to ensure proper functionality.

**TLDR**

* Fix `update` not adding multiple compounds
* Added test case for this issue