### PR TITLE
Ditch archived `ruff` action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,4 +5,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v1

--- a/easyDataverse/base.py
+++ b/easyDataverse/base.py
@@ -395,10 +395,10 @@ class DataverseBase(BaseModel):
 
         for field in block.model_fields.values():
             annot = field.annotation
-            dtype = [t for t in get_args(annot) if t != type(None)][0]
+            dtype = [t for t in get_args(annot) if t is not type(None)][0]
             alias = field.alias
 
-            is_multiple = get_origin(annot) == list
+            is_multiple = get_origin(annot) is list
             is_complex = hasattr(dtype, "model_fields")
 
             if dtype.__name__ == "Annotated":

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -434,9 +434,9 @@ class TestCreateFunctionSignature:
         # Assert
         assert result[0].name == "name"
         assert result[0].default.__name__ == "empty"
-        assert result[0].type == str
+        assert result[0].type is str
         assert result[1].name == "value"
-        assert result[1].type == int
+        assert result[1].type is int
         assert result[1].default.__name__ == "empty"
         assert result[2].name == "optional"
         assert result[2].type == Optional[str]
@@ -665,7 +665,7 @@ class TestGetFieldType:
 
         # Assert
         generated_enum = get_args(result)[0]
-        assert get_args(result)[1] == type(None)
+        assert get_args(result)[1] is type(None)
         assert issubclass(generated_enum, Enum)
         assert generated_enum.__name__ == "single_cv_field"
         assert generated_enum.VALUE1.value == "value1"


### PR DESCRIPTION
The [Ruff GitHub Action](https://github.com/ChartBoost/ruff-action?tab=readme-ov-file) was recently archived and is no longer maintained. This PR follows the recommendation from the archived repository and updates to the officially supported version.

Sneaked fixes for the linter errors inside 🥷