### PR TITLE
Fix attributes starting with numeric names raise `ValueError`

### DIFF
--- a/easyDataverse/classgen.py
+++ b/easyDataverse/classgen.py
@@ -401,6 +401,27 @@ def process_name(attr_name, common_part):
     Returns:
         str: The processed attribute name.
     """
+
+    # If the first letter is not aplhabet, append an underscore
+    if attr_name[0].isnumeric():
+        # Convert number to word
+        mapping = {
+            "0": "zero",
+            "1": "one",
+            "2": "two",
+            "3": "three",
+            "4": "four",
+            "5": "five",
+            "6": "six",
+            "7": "seven",
+            "8": "eight",
+            "9": "nine",
+        }
+        attr_name = mapping[attr_name[0]] + "_" + attr_name[1:]
+    elif not attr_name[0].isalpha():
+        # If the first character is not a letter, remove it
+        attr_name = attr_name[1:]
+
     return camel_to_snake(attr_name).replace(common_part, "", 1).replace(" ", "")
 
 

--- a/easyDataverse/classgen.py
+++ b/easyDataverse/classgen.py
@@ -402,6 +402,9 @@ def process_name(attr_name, common_part):
         str: The processed attribute name.
     """
 
+    if len(attr_name) == 0:
+        raise ValueError("Attribute name cannot be empty.")
+
     # If the first letter is not aplhabet, append an underscore
     if attr_name[0].isnumeric():
         # Convert number to word

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -44,3 +44,13 @@ class TestConnection:
         assert hasattr(citation, "author")
         assert hasattr(citation, "dataset_contact")
         assert hasattr(citation, "ds_description")
+
+    def test_numeric_namespace(self):
+        # Harvard Dataverse hosts a metadata block with first letter numeric
+        # attribute names. Hence, this tests checks if the numeric parts are
+        # parsed correctly.
+
+        try:
+            Dataverse(server_url="https://dataverse.harvard.edu")
+        except ValueError as e:
+            AssertionError("Failed to parse numeric namespace: " + str(e))

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -101,10 +101,8 @@ class TestProcessName:
         common_part = ""
 
         # Act
-        processed_name = process_name(attr_name, common_part)
-
-        # Assert
-        assert processed_name == ""
+        with pytest.raises(ValueError):
+            processed_name = process_name(attr_name, common_part)
 
     # Empty common part returns processed attribute name without common part.
     @pytest.mark.unit

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -102,7 +102,7 @@ class TestProcessName:
 
         # Act
         with pytest.raises(ValueError):
-            processed_name = process_name(attr_name, common_part)
+            process_name(attr_name, common_part)
 
     # Empty common part returns processed attribute name without common part.
     @pytest.mark.unit


### PR DESCRIPTION
**Overview**

This update addresses an issue reported by @kmika11 in the current version of EasyDataverse, where attribute names starting with a numerical character result in a `ValueError` raised by Pydantic, as attribute names cannot begin with a number. 

This PR resolves the issue by converting the initial number into a human-readable string consisting solely of alphabetic characters. Additionally, if the attribute name begins with a non-alphanumeric character (other than a letter), that character will be removed. Serialization and deserialization remain unaffected, as the original name is retained as an alias.

**TLDR**

* Fix handling of attributes that start with a numeric character
* Add tests to validate the new functionality