### PR TITLE
Add license terms

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,6 +1,10 @@
 name: Integration Tests
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'easyDataverse/**'
+      - 'tests/**'
 
 jobs:
   build:
@@ -8,13 +12,13 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     env:
       PORT: 8080
     steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
       - name: Run Dataverse Action
         id: dataverse
         uses: gdcc/dataverse-action@main

--- a/easyDataverse/classgen.py
+++ b/easyDataverse/classgen.py
@@ -405,7 +405,7 @@ def process_name(attr_name, common_part):
     if len(attr_name) == 0:
         raise ValueError("Attribute name cannot be empty.")
 
-    # If the first letter is not aplhabet, append an underscore
+    # If the first letter is not from the alphabet, append an underscore
     if attr_name[0].isnumeric():
         # Convert number to word
         mapping = {

--- a/easyDataverse/license.py
+++ b/easyDataverse/license.py
@@ -1,0 +1,70 @@
+from urllib import parse
+from pydantic import BaseModel, Field
+import requests
+
+
+class License(BaseModel):
+    """
+    Represents a license for a Dataverse dataset.
+
+    This class models the license information including name, URI, and other metadata
+    that can be associated with a dataset in Dataverse.
+    """
+
+    name: str = Field(
+        description="The name of the license",
+    )
+
+    uri: str = Field(
+        description="The URI where the license text can be found",
+    )
+
+    id: int = Field(
+        description="The internal ID of the license in Dataverse",
+    )
+
+    short_description: str = Field(
+        alias="shortDescription",
+        description="A brief description of the license",
+    )
+
+    active: bool = Field(
+        description="Whether the license is active in the Dataverse instance",
+    )
+
+    is_default: bool = Field(
+        alias="isDefault",
+        description="Whether this is the default license in the Dataverse instance",
+    )
+
+    sort_order: int = Field(
+        alias="sortOrder",
+        description="The order in which the license appears in lists",
+    )
+
+    @classmethod
+    def fetch_by_name(cls, name: str, server_url: str) -> "License":
+        """
+        Fetch a license by name from a Dataverse server.
+
+        Args:
+            name (str): The name of the license to fetch
+            server_url (str): The base URL of the Dataverse server
+
+        Returns:
+            License: A License object with the requested license information
+
+        Raises:
+            Exception: If the license cannot be found or if there's an error communicating with the server
+        """
+        response = requests.get(parse.urljoin(server_url, "/api/licenses"))
+
+        if response.status_code != 200:
+            raise Exception(f"Error getting licenses: {response.text}")
+
+        licenses = response.json()["data"]
+
+        try:
+            return next(filter(lambda x: x["name"] == name, licenses))
+        except StopIteration:
+            raise Exception(f"License '{name}' not found at '{server_url}'")

--- a/examples/EasyDataverseBasics.ipynb
+++ b/examples/EasyDataverseBasics.ipynb
@@ -51,7 +51,7 @@
    },
    "outputs": [],
    "source": [
-    "import rich # For printing\n",
+    "import rich  # For printing\n",
     "\n",
     "from easyDataverse import Dataverse"
    ]
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -85,7 +85,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e19a1b5bec6b44a58972f255cba2bec2",
+       "model_id": "7e6de2dc4be34714ac0fab12b3734de4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -126,26 +126,13 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
     "# Connect to a Dataverse instance of choice\n",
     "dataverse = Dataverse(\n",
-    "    server_url='https://demo.dataverse.org', # @param {type:\"string\"}\n",
-    "    api_token='<API_TOKEN>' # @param {type:\"string\"}\n",
+    "    server_url=\"https://demo.dataverse.org\",  # @param {type:\"string\"}\n",
+    "    # api_token=\"<API_TOKEN>\",  # @param {type:\"string\"}\n",
     ")"
    ]
   },
@@ -163,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -190,7 +177,9 @@
       "customCHIA\n",
       "customDigaai\n",
       "citation\n",
-      "customSAEF\n"
+      "customSAEF\n",
+      "computationalworkflow\n",
+      "LocalContextsCVoc\n"
      ]
     }
    ],
@@ -198,8 +187,92 @@
     "# Mode 1: Only names\n",
     "dataverse.list_metadatablocks(detailed=False)\n",
     "\n",
-    "# Mode 2: Names, fields and methods \n",
+    "# Mode 2: Names, fields and methods\n",
     "# dataverse.list_metadatablocks(detailed=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Licenses\n",
+    "\n",
+    "Upon connecting to a Dataverse instance, EasyDataverse will automatically fetch all the licenses available in the instance and store them in the `licenses` attribute of the `Dataverse` instance. The `default_license` attribute will store the default license of the instance, which will be applied to all datasets created through EasyDataverse, if not otherwise specified."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Licenses</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1mLicenses\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- CC0 1.0 (default)\n",
+      "- CC BY 4.0\n",
+      "- CC BY-NC 4.0\n",
+      "- CC BY-NC-ND 4.0\n",
+      "- CC BY-NC-SA 4.0\n",
+      "- CC BY-ND 4.0\n",
+      "- CC BY-SA 4.0\n",
+      "- PDDL-1.0\n",
+      "- ODC-By 1.0\n",
+      "- ODbL 1.0\n",
+      "- OGL UK 3.0\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">License</span><span style=\"font-weight: bold\">(</span>\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">name</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'CC0 1.0'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">uri</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'http://creativecommons.org/publicdomain/zero/1.0'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">id</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">short_description</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Creative Commons CC0 1.0 Universal Public Domain Dedication.'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">active</span>=<span style=\"color: #00ff00; text-decoration-color: #00ff00; font-style: italic\">True</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">is_default</span>=<span style=\"color: #00ff00; text-decoration-color: #00ff00; font-style: italic\">True</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">sort_order</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>\n",
+       "<span style=\"font-weight: bold\">)</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1;35mLicense\u001b[0m\u001b[1m(\u001b[0m\n",
+       "    \u001b[33mname\u001b[0m=\u001b[32m'CC0 1.0'\u001b[0m,\n",
+       "    \u001b[33muri\u001b[0m=\u001b[32m'http://creativecommons.org/publicdomain/zero/1.0'\u001b[0m,\n",
+       "    \u001b[33mid\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
+       "    \u001b[33mshort_description\u001b[0m=\u001b[32m'Creative Commons CC0 1.0 Universal Public Domain Dedication.'\u001b[0m,\n",
+       "    \u001b[33mactive\u001b[0m=\u001b[3;92mTrue\u001b[0m,\n",
+       "    \u001b[33mis_default\u001b[0m=\u001b[3;92mTrue\u001b[0m,\n",
+       "    \u001b[33msort_order\u001b[0m=\u001b[1;36m0\u001b[0m\n",
+       "\u001b[1m)\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# You can list the licenses available in the Dataverse instance\n",
+    "dataverse.list_licenses()\n",
+    "\n",
+    "# The default license can be accessed as follows:\n",
+    "rich.print(dataverse.default_license)\n"
    ]
   },
   {
@@ -242,7 +315,7 @@
    "source": [
     "dataset = dataverse.create_dataset()\n",
     "\n",
-    "print(dataset) # Should be empty by now"
+    "print(dataset)  # Should be empty by now"
    ]
   },
   {
@@ -498,21 +571,21 @@
     "from pydantic import ValidationError\n",
     "\n",
     "try:\n",
-    "  # Adding a non-list element\n",
-    "  dataset.geospatial.unit = \"unit\"\n",
+    "    # Adding a non-list element\n",
+    "    dataset.geospatial.unit = \"unit\"\n",
     "except ValidationError as e:\n",
-    "  rich.print(e)\n",
+    "    rich.print(e)\n",
     "\n",
     "try:\n",
-    "  # Adding a value that is not part of a controlled vocab\n",
-    "  dataset.geospatial.add_coverage(\n",
-    "      country=\"germany\",\n",
-    "      state=\"BW\",\n",
-    "      city=\"Stuttgart\",\n",
-    "  )\n",
+    "    # Adding a value that is not part of a controlled vocab\n",
+    "    dataset.geospatial.add_coverage(\n",
+    "        country=\"germany\",\n",
+    "        state=\"BW\",\n",
+    "        city=\"Stuttgart\",\n",
+    "    )\n",
     "except ValidationError as e:\n",
-    "  # ... you see the world is quite large :')\n",
-    "  rich.print(e)"
+    "    # ... you see the world is quite large :')\n",
+    "    rich.print(e)"
    ]
   },
   {
@@ -577,9 +650,9 @@
    "source": [
     "# Upload a single file\n",
     "dataset.add_file(\n",
-    "    local_path=\"./data/anscomb.json\", # Path to the file on your system\n",
-    "    dv_dir=\"some/sub/dir\", # Optional sub directory on Dataverse\n",
-    "    file_name=\"different_name.json\" # Optional renaming of the file\n",
+    "    local_path=\"./data/anscomb.json\",  # Path to the file on your system\n",
+    "    dv_dir=\"some/sub/dir\",  # Optional sub directory on Dataverse\n",
+    "    file_name=\"different_name.json\",  # Optional renaming of the file\n",
     ")\n",
     "\n",
     "\n",
@@ -587,9 +660,9 @@
     "dataset.add_directory(\n",
     "    dirpath=\"./data\",\n",
     "    ignores=[\n",
-    "        r\"anscomb.json\", # Ignore the previously added file\n",
-    "        \"^\\..*\",         # Ignore hidden files and dirs\n",
-    "    ]\n",
+    "        r\"anscomb.json\",  # Ignore the previously added file\n",
+    "        \"^\\..*\",  # Ignore hidden files and dirs\n",
+    "    ],\n",
     ")\n",
     "\n",
     "# Check if all the files have been added\n",
@@ -1047,7 +1120,14 @@
     }
    ],
    "source": [
-    "pid = dataset.upload(dataverse_name=\"ed_test\", n_parallel=4)"
+    "# If you opt for a different license, you can do so by providing the license name to the `license` argument.\n",
+    "dataset.license = dataverse.licenses[\"CC BY 4.0\"]  # Will set to CC BY 4.0\n",
+    "\n",
+    "# Upload the dataset to the Dataverse instance\n",
+    "pid = dataset.upload(\n",
+    "    dataverse_name=\"ed_test\",  # Name of the collection to upload to\n",
+    "    n_parallel=4,  # Upload 4 files in parallel\n",
+    ")"
    ]
   },
   {
@@ -1391,9 +1471,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "easydataverse",
+   "display_name": "base",
    "language": "python",
-   "name": "easydataverse"
+   "name": "base"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1405,7 +1485,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/EasyDataverseBasics.ipynb
+++ b/examples/EasyDataverseBasics.ipynb
@@ -132,7 +132,7 @@
     "# Connect to a Dataverse instance of choice\n",
     "dataverse = Dataverse(\n",
     "    server_url=\"https://demo.dataverse.org\",  # @param {type:\"string\"}\n",
-    "    # api_token=\"<API_TOKEN>\",  # @param {type:\"string\"}\n",
+    "    api_token=\"<API_TOKEN>\",  # @param {type:\"string\"}\n",
     ")"
    ]
   },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,3 +26,11 @@ def minimal_upload():
         dict: The contents of the 'minimal_upload.json' file.
     """
     return json.load(open("tests/fixtures/minimal_upload.json"))
+
+
+@pytest.fixture()
+def minimal_upload_other_license():
+    """
+    Returns the contents of the 'minimal_upload.json' file as a dictionary.
+    """
+    return json.load(open("tests/fixtures/minimal_upload_other_license.json"))

--- a/tests/fixtures/minimal_upload_other_license.json
+++ b/tests/fixtures/minimal_upload_other_license.json
@@ -1,6 +1,6 @@
 {
   "datasetVersion": {
-    "license": "CC0 1.0",
+    "license": "CC BY 4.0",
     "metadataBlocks": {
       "citation": {
         "fields": [

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -1,5 +1,7 @@
-from pyDataverse.api import NativeApi
 import pytest
+
+from pyDataverse.api import NativeApi
+from easyDataverse.license import License
 from easyDataverse.dataverse import Dataverse
 
 
@@ -44,6 +46,27 @@ class TestConnection:
         assert hasattr(citation, "author")
         assert hasattr(citation, "dataset_contact")
         assert hasattr(citation, "ds_description")
+
+    def test_license_list(self, credentials):
+        # Arrange
+        base_url, api_token = credentials
+        dataverse = Dataverse(
+            server_url=base_url,
+            api_token=api_token,
+        )
+
+        # Act
+        licenses = dataverse.licenses
+        default_license = dataverse.default_license
+
+        # Assert
+        assert len(licenses) > 0
+        assert isinstance(licenses, dict)
+        assert isinstance(list(licenses.values())[0], License)
+
+        assert isinstance(default_license, License)
+        assert default_license.is_default
+        assert default_license.name == "CC0 1.0"
 
     def test_numeric_namespace(self):
         # Harvard Dataverse hosts a metadata block with first letter numeric

--- a/tests/integration/test_dataset_creation.py
+++ b/tests/integration/test_dataset_creation.py
@@ -40,6 +40,42 @@ class TestDatasetCreation:
 
         assert self.sort_citation(dataset) == minimal_upload
 
+    @pytest.mark.integration
+    def test_creation_other_license(
+        self,
+        credentials,
+        minimal_upload_other_license,
+    ):
+        # Arrange
+        base_url, api_token = credentials
+        dataverse = Dataverse(
+            server_url=base_url,
+            api_token=api_token,
+        )
+
+        # Act
+        dataset = dataverse.create_dataset()
+        dataset.license = dataverse.licenses["CC BY 4.0"]
+
+        dataset.citation.title = "My dataset"
+        dataset.citation.subject = ["Other"]
+        dataset.citation.add_author(name="John Doe")
+        dataset.citation.add_ds_description(
+            value="This is a description of the dataset",
+            date="2024",
+        )
+        dataset.citation.add_dataset_contact(
+            name="John Doe",
+            email="john@doe.com",
+        )
+
+        dataset.add_directory(
+            dirpath="./tests/fixtures",
+            dv_dir="some/sub/dir",
+        )
+
+        assert self.sort_citation(dataset) == minimal_upload_other_license
+
     @staticmethod
     def sort_citation(dataset: Dataset):
         dv_dict = dataset.dataverse_dict()

--- a/tests/integration/test_dataset_download.py
+++ b/tests/integration/test_dataset_download.py
@@ -15,7 +15,6 @@ class TestDatasetDownload:
         credentials,
         minimal_upload,
     ):
-
         # Arrange
         base_url, api_token = credentials
         url = f"{base_url}/api/dataverses/root/datasets"
@@ -43,9 +42,9 @@ class TestDatasetDownload:
         expected = self.sort_citation(minimal_upload)
         result = self.sort_citation(dataset.dataverse_dict())
 
-        assert (
-            result == expected
-        ), "The downloaded dataset does not match the expected dataset."
+        assert result == expected, (
+            "The downloaded dataset does not match the expected dataset."
+        )
 
     @pytest.mark.integration
     def test_dataset_download_with_file(
@@ -53,7 +52,6 @@ class TestDatasetDownload:
         credentials,
         minimal_upload,
     ):
-
         # Arrange
         base_url, api_token = credentials
         url = f"{base_url}/api/dataverses/root/datasets"
@@ -95,16 +93,16 @@ class TestDatasetDownload:
         expected = self.sort_citation(minimal_upload)
         result = self.sort_citation(dataset.dataverse_dict())
 
-        assert (
-            result == expected
-        ), "The downloaded dataset does not match the expected dataset."
+        assert result == expected, (
+            "The downloaded dataset does not match the expected dataset."
+        )
 
-        assert (
-            len(dataset.files) == 1
-        ), "The dataset does not contain the expected number of files."
-        assert (
-            dataset.files[0].filepath == "./test_file.txt"
-        ), "The file path does not match the expected file path."
+        assert len(dataset.files) == 1, (
+            "The dataset does not contain the expected number of files."
+        )
+        assert dataset.files[0].filepath == "./test_file.txt", (
+            "The file path does not match the expected file path."
+        )
         assert os.path.exists(dataset.files[0].filepath), "The file was not downloaded."
         assert (
             open("tests/fixtures/test_file.txt", "rb").read()
@@ -117,7 +115,6 @@ class TestDatasetDownload:
         credentials,
         minimal_upload,
     ):
-
         # Arrange
         base_url, api_token = credentials
         url = f"{base_url}/api/dataverses/root/datasets"
@@ -162,16 +159,16 @@ class TestDatasetDownload:
         expected = self.sort_citation(minimal_upload)
         result = self.sort_citation(dataset.dataverse_dict())
 
-        assert (
-            result == expected
-        ), "The downloaded dataset does not match the expected dataset."
+        assert result == expected, (
+            "The downloaded dataset does not match the expected dataset."
+        )
 
-        assert (
-            len(dataset.files) == 1
-        ), "The dataset does not contain the expected number of files."
-        assert (
-            dataset.files[0].filepath == "./test_file.txt"
-        ), "The file path does not match the expected file path."
+        assert len(dataset.files) == 1, (
+            "The dataset does not contain the expected number of files."
+        )
+        assert dataset.files[0].filepath == "./test_file.txt", (
+            "The file path does not match the expected file path."
+        )
         assert os.path.exists(dataset.files[0].filepath), "The file was not downloaded."
         assert (
             open("tests/fixtures/test_file.txt", "rb").read()


### PR DESCRIPTION
As noted in #29 and discussions with @pdurbin, this PR enhances EasyDataverse by introducing features for adding and retrieving license terms for each dataset. Licenses are sourced from the corresponding Dataverse instance and saved within the `Dataverse` class instance under `licenses` and `default_license`. The latter is determined by the `is_default` property provided by the endpoint.

### Usage

By default, EasyDataverse will assign the license specified by the Dataverse instance. However, users are free to select from the available licenses:

```python
dataverse = Dataverse("https://demo.dataverse.org")
dataset = dataverse.create_dataset()

# For convenience, users can list available licenses
dataverse.list_licenses()

dataset.license = dataverse.licenses["CC By 4.0"]
```

When uploaded, the chosen license will be added to the Dataverse JSON and configured on the server side. Upon retrieving a dataset, the license will be processed, and additional details will be extracted from the Dataverse instance, as the Dataverse JSON includes only basic license information. Consequently, attributes like `uri` and `short_description` will be available in the `dataset.license` instance.

### Design choices

Choosing to depend on `api/licenses` for dynamically fetching licenses is grounded in several key reasons related to consistency and the overarching philosophy of EasyDataverse: 

* It supports the library’s dynamic character, allowing it to adjust to different instances. 
* Merely offering a `str` might lead to inconsistencies that would only be identified on the server side. 
* Enhances user experience by removing the need to determine which licenses are available.

### Other

* Tests have been added to validate correct behavior
* Closes #29 