### PR TITLE
Migrate to `httpx`

### DIFF
--- a/easyDataverse/dataverse.py
+++ b/easyDataverse/dataverse.py
@@ -4,7 +4,7 @@ import json
 from typing import Callable, Dict, List, Optional, Tuple, IO
 from urllib import parse
 
-import requests
+import httpx
 from easyDataverse.license import License
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -110,7 +110,7 @@ class Dataverse(BaseModel):
             url (AnyHttpUrl): URL to the Dataverse installation
 
         Raises:
-            requests.HTTPError: When the URL does not point to a valid DV
+            httpx.HTTPError: When the URL does not point to a valid DV
 
         Returns:
             Dataset: Object that contains all metadatablocks
@@ -198,9 +198,7 @@ class Dataverse(BaseModel):
         Raises:
             ValueError: If the server URL is not a valid Dataverse installation or version info is not found.
         """
-        response = requests.get(
-            parse.urljoin(str(self.server_url), "/api/info/version")
-        )
+        response = httpx.get(parse.urljoin(str(self.server_url), "/api/info/version"))
 
         if response.status_code != 200:
             raise ValueError(
@@ -218,7 +216,7 @@ class Dataverse(BaseModel):
 
     def _fetch_licenses(self) -> Dict[str, License]:
         """Fetches the licenses from the Dataverse installation."""
-        response = requests.get(parse.urljoin(str(self.server_url), "/api/licenses"))
+        response = httpx.get(parse.urljoin(str(self.server_url), "/api/licenses"))
 
         if response.status_code != 200:
             raise Exception(f"Error getting licenses: {response.text}")
@@ -411,7 +409,8 @@ class Dataverse(BaseModel):
         if version != "latest":
             return self._fetch_dataset_version(pid, str(version))
 
-        return DottedDict(requests.get(url, headers=header).json())
+        response = httpx.get(url, headers=header)
+        return DottedDict(response.json())
 
     def _fetch_files(
         self,

--- a/easyDataverse/license.py
+++ b/easyDataverse/license.py
@@ -1,6 +1,6 @@
 from urllib import parse
 from pydantic import BaseModel, Field
-import requests
+import httpx
 
 
 class License(BaseModel):
@@ -57,7 +57,7 @@ class License(BaseModel):
         Raises:
             Exception: If the license cannot be found or if there's an error communicating with the server
         """
-        response = requests.get(parse.urljoin(server_url, "/api/licenses"))
+        response = httpx.get(parse.urljoin(server_url, "/api/licenses"))
 
         if response.status_code != 200:
             raise Exception(f"Error getting licenses: {response.text}")

--- a/easyDataverse/uploader.py
+++ b/easyDataverse/uploader.py
@@ -1,5 +1,5 @@
 from urllib.parse import urljoin
-import requests
+import httpx
 
 from rich.panel import Panel
 from rich.console import Console
@@ -165,11 +165,11 @@ def _update_metadata(
         api_token (str): API token of the user.
 
     Raises:
-        requests.HTTPError: If the request fails.
+        httpx.HTTPError: If the request fails.
     """
+
     EDIT_ENDPOINT = f"{base_url.rstrip('/')}/api/datasets/:persistentId/editMetadata?persistentId={p_id}&replace=true"
     headers = {"X-Dataverse-key": api_token}
 
-    response = requests.put(EDIT_ENDPOINT, headers=headers, json=to_change)
-
+    response = httpx.put(EDIT_ENDPOINT, headers=headers, json=to_change)
     response.raise_for_status()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,9 @@ dotted-dict = "1.1.3"
 rich = "^13.7.1"
 nob = "^0.8.2"
 nest-asyncio = "^1.6.0"
-aiohttp = "^3.9.5"
-aiodns = "^3.2.0"
 dvuploader = "^0.2.3"
 email-validator = "^2.1.1"
+httpx = "0.28"
 
 [tool.poetry.group.test.dependencies]
 pytest-cov = "^5.0.0"

--- a/tests/integration/test_dataset_download.py
+++ b/tests/integration/test_dataset_download.py
@@ -3,7 +3,7 @@ import os
 from typing import Dict
 
 import pytest
-import requests
+import httpx
 
 from easyDataverse import Dataverse
 
@@ -18,7 +18,7 @@ class TestDatasetDownload:
         # Arrange
         base_url, api_token = credentials
         url = f"{base_url}/api/dataverses/root/datasets"
-        response = requests.post(
+        response = httpx.post(
             url=url,
             json=minimal_upload,
             headers={
@@ -55,7 +55,7 @@ class TestDatasetDownload:
         # Arrange
         base_url, api_token = credentials
         url = f"{base_url}/api/dataverses/root/datasets"
-        response = requests.post(
+        response = httpx.post(
             url=url,
             json=minimal_upload,
             headers={
@@ -70,14 +70,15 @@ class TestDatasetDownload:
         # Add a file to the dataset
         url = f"{base_url}/api/datasets/:persistentId/add?persistentId={pid}"
         json_data = {"description": "Test"}
-        response = requests.post(
-            url=url,
-            headers={
-                "X-Dataverse-key": api_token,
-            },
-            data={"jsonData": json.dumps(json_data)},
-            files={"file": open("tests/fixtures/test_file.txt", "rb")},
-        )
+        with open("tests/fixtures/test_file.txt", "rb") as file:
+            response = httpx.post(
+                url=url,
+                headers={
+                    "X-Dataverse-key": api_token,
+                },
+                data={"jsonData": json.dumps(json_data)},
+                files={"file": file},
+            )
 
         response.raise_for_status()
 
@@ -118,7 +119,7 @@ class TestDatasetDownload:
         # Arrange
         base_url, api_token = credentials
         url = f"{base_url}/api/dataverses/root/datasets"
-        response = requests.post(
+        response = httpx.post(
             url=url,
             json=minimal_upload,
             headers={
@@ -133,14 +134,15 @@ class TestDatasetDownload:
         # Add a file to the dataset
         url = f"{base_url}/api/datasets/:persistentId/add?persistentId={pid}"
         json_data = {"description": "Test"}
-        response = requests.post(
-            url=url,
-            headers={
-                "X-Dataverse-key": api_token,
-            },
-            data={"jsonData": json.dumps(json_data)},
-            files={"file": open("tests/fixtures/test_file.txt", "rb")},
-        )
+        with open("tests/fixtures/test_file.txt", "rb") as file:
+            response = httpx.post(
+                url=url,
+                headers={
+                    "X-Dataverse-key": api_token,
+                },
+                data={"jsonData": json.dumps(json_data)},
+                files={"file": file},
+            )
 
         response.raise_for_status()
 

--- a/tests/integration/test_dataset_update.py
+++ b/tests/integration/test_dataset_update.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 import pytest
-import requests
+import httpx
 
 from easyDataverse import Dataverse
 
@@ -13,11 +13,10 @@ class TestDatasetUpdate:
         credentials,
         minimal_upload,
     ):
-
         # Arrange
         base_url, api_token = credentials
         url = f"{base_url}/api/dataverses/root/datasets"
-        response = requests.post(
+        response = httpx.post(
             url=url,
             json=minimal_upload,
             headers={
@@ -45,7 +44,7 @@ class TestDatasetUpdate:
             f"{base_url}/api/datasets/:persistentId/versions/:draft?persistentId={pid}"
         )
 
-        response = requests.get(
+        response = httpx.get(
             url,
             headers={"X-Dataverse-key": api_token},
         )
@@ -60,9 +59,9 @@ class TestDatasetUpdate:
         )
 
         # Assert
-        assert (
-            title_field["value"] == "Title has changed"
-        ), "The updated dataset title does not match the expected title."
+        assert title_field["value"] == "Title has changed", (
+            "The updated dataset title does not match the expected title."
+        )
 
     @staticmethod
     def sort_citation(dataset: Dict):


### PR DESCRIPTION
This pull request replaces all `requests` and `aiohttp` calls and dependencies with `httpx`. It brings the codebase in line with the other Python Dataverse libraries, creating a uniform set of dependencies across projects. This update is particularly important since [python-dvuploader](https://github.com/gdcc/python-dvuploader) has already migrated to `httpx` and is a dependency of EasyDataverse.


* Closes #40 