### PR TITLE
Update GitHub workflows to include `3.12` and `3.13`

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'easyDataverse/**'
       - 'tests/**'
+      - '.github/workflows/integration-tests.yaml'
 
 jobs:
   build:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     env:
       PORT: 8080

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,6 +1,11 @@
 name: Unit Tests
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'easyDataverse/**'
+      - 'tests/**'
+      - '.github/workflows/unit-tests.yaml'
 
 jobs:
   build:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR extends the GitHub test workflows to accommodate for Python 3.12 and 3.13.