### PR TITLE
Follow redirects when downloading files

### DIFF
--- a/easyDataverse/downloader.py
+++ b/easyDataverse/downloader.py
@@ -153,7 +153,7 @@ async def _download_file(
 
     url = f"/api/access/datafile/{file_id}"
 
-    async with client.stream("GET", url) as response:
+    async with client.stream("GET", url, follow_redirects=True) as response:
         response.raise_for_status()
         os.makedirs(os.path.dirname(local_path), exist_ok=True)
 


### PR DESCRIPTION
This PR addresses the problem that httpx does not follow redirects by default. However, since the Dataverse instance likely redirects to S3 storage, redirects will occur. Therefore, this PR activates redirects to resolve the issue.