### PR TITLE
Fix custom terms

### DIFF
--- a/easyDataverse/__init__.py
+++ b/easyDataverse/__init__.py
@@ -1,6 +1,9 @@
 from .dataset import Dataset  # noqa: F401
 from .dataverse import Dataverse  # noqa: F401
+from .license import CustomLicense, License  # noqa: F401
 import nest_asyncio
+
+__all__ = ["Dataset", "Dataverse", "CustomLicense", "License"]
 
 nest_asyncio.apply()
 

--- a/easyDataverse/dataset.py
+++ b/easyDataverse/dataset.py
@@ -183,13 +183,12 @@ class Dataset(BaseModel):
         for block in self.metadatablocks.values():
             blocks.update(block.dataverse_dict())
 
-        match self.license:
-            case License():
-                terms = {"license": self.license.name}
-            case CustomLicense():
-                terms = self.license.model_dump(by_alias=True, exclude={"name"})
-            case _:
-                terms = {}
+        if isinstance(self.license, License):
+            terms = {"license": self.license.name}
+        elif isinstance(self.license, CustomLicense):
+            terms = self.license.model_dump(by_alias=True, exclude={"name"})
+        else:
+            terms = {}
 
         return {
             "datasetVersion": {

--- a/easyDataverse/dataset.py
+++ b/easyDataverse/dataset.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Union
 import nob
 import xmltodict
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 from dvuploader import File, add_directory
 

--- a/easyDataverse/downloader.py
+++ b/easyDataverse/downloader.py
@@ -168,7 +168,7 @@ async def _download_file(
 
     return File(
         filepath=local_path,
-        file_id=str(file_id),
+        file_id=str(file_id),  # type: ignore
         **file,
     )
 

--- a/easyDataverse/license.py
+++ b/easyDataverse/license.py
@@ -1,5 +1,6 @@
+from typing import Optional
 from urllib import parse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 import httpx
 
 
@@ -68,3 +69,64 @@ class License(BaseModel):
             return next(filter(lambda x: x["name"] == name, licenses))
         except StopIteration:
             raise Exception(f"License '{name}' not found at '{server_url}'")
+
+
+class CustomLicense(BaseModel):
+    """
+    Represents a custom license for a Dataverse dataset.
+
+    This class models the custom terms of use information including name, URI, and other metadata
+    that can be associated with a dataset in Dataverse.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+
+    terms_of_use: Optional[str] = Field(
+        default=None,
+        description="The terms of use of the dataset.",
+        alias="termsOfUse",
+    )
+
+    confidentiality_declaration: Optional[str] = Field(
+        default=None,
+        description="The confidentiality declaration of the dataset.",
+        alias="confidentialityDeclaration",
+    )
+
+    special_permissions: Optional[str] = Field(
+        default=None,
+        description="Special permissions for the dataset.",
+        alias="specialPermissions",
+    )
+
+    restrictions: Optional[str] = Field(
+        default=None,
+        description="Restrictions applied to the dataset.",
+        alias="restrictions",
+    )
+
+    citation_requirements: Optional[str] = Field(
+        default=None,
+        description="Requirements for citing the dataset.",
+        alias="citationRequirements",
+    )
+
+    depositor_requirements: Optional[str] = Field(
+        default=None,
+        description="Requirements for depositors of the dataset.",
+        alias="depositorRequirements",
+    )
+
+    conditions: Optional[str] = Field(
+        default=None,
+        description="Conditions for using the dataset.",
+        alias="conditions",
+    )
+
+    disclaimer: Optional[str] = Field(
+        default=None,
+        description="Disclaimer for the dataset.",
+        alias="disclaimer",
+    )

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -6,10 +6,8 @@ from easyDataverse.base import DataverseBase
 
 
 class TestBase:
-
     @pytest.mark.unit
     def test_template(self):
-
         # Arrange
         class Child(DataverseBase):
             bar: Optional[str] = Field(
@@ -18,7 +16,6 @@ class TestBase:
             )
 
         class Test(DataverseBase):
-
             foo: Optional[str] = Field(
                 default=None,
                 alias="Foo",


### PR DESCRIPTION
This PR extends the library to support **custom terms**, which are treated differently than the standard `license` field. This enhancement addresses the use case raised in #46 regarding custom terms of use. Additionally, it resolves issue #45, where fields like `SocialScienceNotes` (which is a sinfle-valued compound) were parsed incorrectly, resulting in a `DottedDict` holding the raw response and triggering a `ValidationError`.

### Implementation Details

Dataverse responses may include a set of custom term fields that appear at the root level of the JSON. This PR introduces a new `CustomLicense` class to encapsulate and parse these fields. The decision to extract this into a separate class is motivated by two key considerations:

- Both `License` and `CustomLicense` are exposed via the same `license` property on the `Dataset`, maintaining a clean API and avoiding the need to manage additional initialization properties.
- Mapping both to the same `license` field reflects Dataverse behavior, where either a standard license or custom terms may be present — but not both.

### Example Usage

```python
# Setting a custom license
dataset = dataverse.create_dataset()
dataset.license = CustomLicense(
    termsOfUse="This is a custom terms of use",
    confidentialityDeclaration="This is a custom confidentiality declaration",
    specialPermissions="This is a custom special permissions",
    restrictions="This is a custom restrictions",
    citationRequirements="This is a custom citation requirements",
    depositorRequirements="This is a custom depositor requirements",
    conditions="This is a custom conditions",
    disclaimer="This is a custom disclaimer",
)
```

* Closes #46 
* Closes #45 