### PR TITLE
Add dataset types to `Dataset` and `Dataverse`

### DIFF
--- a/easyDataverse/datasettype.py
+++ b/easyDataverse/datasettype.py
@@ -1,0 +1,64 @@
+from typing import List
+from urllib.parse import urljoin
+from pydantic import BaseModel, Field
+import httpx
+from pyDataverse.api import NativeApi
+
+
+class DatasetType(BaseModel):
+    """
+    Represents a dataset type in Dataverse.
+
+    A dataset type defines the structure and metadata requirements for datasets
+    in a Dataverse instance, including which metadata blocks are linked to it.
+    """
+
+    id: int = Field(..., description="The ID of the dataset type")
+    name: str = Field(..., description="The name of the dataset type")
+    linkedMetadataBlocks: list[str] = Field(
+        default_factory=list,
+        description="The metadata blocks linked to the dataset type",
+    )
+
+    @classmethod
+    def from_instance(cls, base_url: str) -> List["DatasetType"]:
+        """
+        Retrieve all dataset types from a Dataverse instance.
+
+        Args:
+            base_url: The base URL of the Dataverse instance
+
+        Returns:
+            A list of DatasetType objects representing all dataset types
+            available in the Dataverse instance
+
+        Raises:
+            httpx.HTTPStatusError: If the API request fails
+            ValueError: If the Dataverse instance is not at least version 6.4
+        """
+        native_api = NativeApi(base_url=base_url)
+
+        if cls._get_version(native_api) < (6, 4):
+            raise ValueError(
+                "Dataset types are only supported in Dataverse 6.4 and above"
+            )
+
+        url = urljoin(native_api.base_url, "api/datasets/datasetTypes")
+        response = httpx.get(url)
+
+        if not response.is_success:
+            # If there are no dataset types, the response is a 200 with an empty list
+            return []
+
+        return [cls.model_validate(item) for item in response.json()["data"]]
+
+    @staticmethod
+    def _get_version(native_api: NativeApi) -> tuple[int, int]:
+        """
+        Get the version of the Dataverse instance.
+        """
+        response = native_api.get_info_version()
+        response.raise_for_status()
+        version = response.json()["data"]["version"]
+        major, minor = version.split(".", 1)
+        return int(major), int(minor)

--- a/easyDataverse/dataverse.py
+++ b/easyDataverse/dataverse.py
@@ -406,7 +406,6 @@ class Dataverse(BaseModel):
 
         # Fetch and extract data
         remote_ds = self._fetch_dataset(pid, version)
-        rich.print(remote_ds)
 
         # Get the latest version data
         latest_version = remote_ds.data.latestVersion  # type: ignore

--- a/easyDataverse/dataverse.py
+++ b/easyDataverse/dataverse.py
@@ -1,11 +1,13 @@
 import asyncio
 from copy import deepcopy
+from functools import cached_property
 import json
 from uuid import UUID
 from typing import Callable, Dict, List, Optional, Tuple, IO
 from urllib import parse
 
 import httpx
+from easyDataverse.datasettype import DatasetType
 from easyDataverse.license import CustomLicense, License
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -111,6 +113,25 @@ class Dataverse(BaseModel):
     def default_license(self) -> License:
         """The default license of the Dataverse installation."""
         return next(filter(lambda x: x.is_default, self.licenses.values()))
+
+    @computed_field(
+        description="The dataset types available in the Dataverse installation."
+    )
+    @cached_property
+    def dataset_types(self) -> Dict[str, DatasetType]:
+        """The dataset types available in the Dataverse installation."""
+        if self.native_api is None:
+            raise ValueError(
+                "Native API is not available. Please connect to a Dataverse installation first."
+            )
+
+        try:
+            return {
+                dataset_type.name: dataset_type
+                for dataset_type in DatasetType.from_instance(self.native_api.base_url)
+            }
+        except ValueError:
+            return {}
 
     def _connect(self) -> None:
         """Connects to a Dataverse installation and adds all metadtablocks as classes.
@@ -278,6 +299,17 @@ class Dataverse(BaseModel):
 
         print("\n")
 
+    def list_dataset_types(self):
+        """Lists the dataset types available in the Dataverse installation."""
+        rich.print("[bold]Dataset Types[/bold]")
+        for dataset_type in self.dataset_types.values():
+            if dataset_type.name == "dataset":
+                print(f"- {dataset_type.name} (default)")
+            else:
+                print(f"- {dataset_type.name}")
+
+        print("\n")
+
     # ! Dataset Handlers
 
     def create_dataset(self) -> Dataset:
@@ -287,7 +319,9 @@ class Dataverse(BaseModel):
         Returns:
             Dataset: The newly created dataset.
         """
-        return self._dataset_gen()
+        dataset = self._dataset_gen()
+        dataset._dataverse = self
+        return dataset
 
     @classmethod
     def load_from_url(
@@ -372,6 +406,7 @@ class Dataverse(BaseModel):
 
         # Fetch and extract data
         remote_ds = self._fetch_dataset(pid, version)
+        rich.print(remote_ds)
 
         # Get the latest version data
         latest_version = remote_ds.data.latestVersion  # type: ignore
@@ -386,6 +421,7 @@ class Dataverse(BaseModel):
                 dataset.license = custom_license
 
         dataset.p_id = latest_version.datasetPersistentId  # type: ignore
+        dataset.dataset_type = remote_ds.data.get("datasetType", None)  # type: ignore
         blocks = latest_version.metadataBlocks  # type: ignore
         files = latest_version.files  # type: ignore
 

--- a/easyDataverse/uploader.py
+++ b/easyDataverse/uploader.py
@@ -34,7 +34,7 @@ def upload_to_dataverse(
         str: The resulting DOI of the dataset, if successful.
     """
 
-    api, _ = _initialize_pydataverse(DATAVERSE_URL, API_TOKEN)
+    api, _ = _initialize_pydataverse(DATAVERSE_URL, API_TOKEN)  # type: ignore
     ds = Dataset()
     ds.from_json(json_data)
 
@@ -50,7 +50,7 @@ def upload_to_dataverse(
     if p_id:
         create_params["pid"] = p_id
 
-    response = api.create_dataset(**create_params)
+    response = api.create_dataset(**create_params)  # type: ignore
     response.raise_for_status()
 
     # Get response data
@@ -58,13 +58,13 @@ def upload_to_dataverse(
 
     _uploadFiles(
         files=files,
-        p_id=p_id,
-        api=api,
+        p_id=p_id,  # type: ignore
+        api=api,  # type: ignore
         n_parallel=n_parallel,
     )  # type: ignore
 
     console = Console()
-    url = urljoin(DATAVERSE_URL, f"dataset.xhtml?persistentId={p_id}")
+    url = urljoin(DATAVERSE_URL, f"dataset.xhtml?persistentId={p_id}")  # type: ignore
     panel = Panel(
         f"🎉 {url}",
         title="Dataset URL",

--- a/tests/integration/test_dataset_creation.py
+++ b/tests/integration/test_dataset_creation.py
@@ -1,4 +1,5 @@
 import os
+from pydantic import ValidationError
 import pytest
 from easyDataverse.dataset import Dataset
 
@@ -94,6 +95,59 @@ class TestDatasetCreation:
             assert "some/sub/dir" in file.directory_label, (
                 "File should be in the sub-directory"
             )
+
+    @pytest.mark.integration
+    def test_creation_and_upload_with_dataset_type(
+        self,
+        credentials,
+    ):
+        # Arrange
+        base_url, api_token = credentials
+        dataverse = Dataverse(
+            server_url=base_url,
+            api_token=api_token,
+        )
+
+        # Act
+        dataset = dataverse.create_dataset()
+
+        dataset.dataset_type = "dataset"
+        dataset.citation.title = "My dataset"
+        dataset.citation.subject = ["Other"]
+        dataset.citation.add_author(name="John Doe")
+        dataset.citation.add_ds_description(
+            value="This is a description of the dataset",
+            date="2024",
+        )
+        dataset.citation.add_dataset_contact(
+            name="John Doe",
+            email="john@doe.com",
+        )
+
+        pid = dataset.upload(dataverse_name="root")
+
+        # Re-fetch the dataset
+        dataset = dataverse.load_dataset(pid)
+
+        assert dataset.dataset_type == "dataset"
+
+    @pytest.mark.integration
+    def test_creation_invalid_dataset_type(
+        self,
+        credentials,
+    ):
+        # Arrange
+        base_url, api_token = credentials
+        dataverse = Dataverse(
+            server_url=base_url,
+            api_token=api_token,
+        )
+
+        # Act
+        dataset = dataverse.create_dataset()
+
+        with pytest.raises(ValidationError):
+            dataset.dataset_type = "invalid"
 
     @pytest.mark.integration
     def test_creation_other_license(
@@ -227,6 +281,7 @@ class TestDatasetCreation:
     @staticmethod
     def sort_citation(dataset: Dataset):
         dv_dict = dataset.dataverse_dict()
+        del dv_dict["datasetType"]
         citation = dv_dict["datasetVersion"]["metadataBlocks"]["citation"]
         citation_fields = citation["fields"]
         dv_dict["datasetVersion"]["metadataBlocks"]["citation"]["fields"] = sorted(

--- a/tests/integration/test_dataset_download.py
+++ b/tests/integration/test_dataset_download.py
@@ -179,6 +179,9 @@ class TestDatasetDownload:
 
     @staticmethod
     def sort_citation(dataset: Dict):
+        if "datasetType" in dataset:
+            del dataset["datasetType"]
+
         citation = dataset["datasetVersion"]["metadataBlocks"]["citation"]
         citation_fields = citation["fields"]
         dataset["datasetVersion"]["metadataBlocks"]["citation"]["fields"] = sorted(

--- a/tests/integration/test_dataset_update.py
+++ b/tests/integration/test_dataset_update.py
@@ -36,7 +36,7 @@ class TestDatasetUpdate:
 
         # Fetch the dataset and update the title
         dataset = dataverse.load_dataset(pid)
-        dataset.citation.title = "Title has changed"
+        dataset.citation.title = "Title has changed"  # type: ignore
         dataset.update()
 
         # Re-fetch the dataset

--- a/tests/integration/test_datasettype.py
+++ b/tests/integration/test_datasettype.py
@@ -1,0 +1,27 @@
+import pytest
+from easyDataverse.datasettype import DatasetType
+
+
+class TestDatasetType:
+    """Integration tests for DatasetType functionality."""
+
+    @pytest.mark.integration
+    def test_dataset_type_from_instance(self, credentials):
+        """
+        Test retrieving dataset types from a Dataverse instance.
+
+        This test verifies that we can successfully fetch dataset types
+        from a Dataverse installation and that the returned data matches
+        the expected structure.
+
+        Args:
+            credentials: Fixture providing base_url and api_token for testing
+        """
+        base_url, _ = credentials
+        dataset_types = DatasetType.from_instance(base_url)
+
+        assert len(dataset_types) > 0
+        expected_dataset_types = [
+            DatasetType(id=1, name="dataset", linkedMetadataBlocks=[]),
+        ]
+        assert dataset_types == expected_dataset_types

--- a/tests/unit/test_dataverse.py
+++ b/tests/unit/test_dataverse.py
@@ -9,8 +9,8 @@ class TestDataverse:
         """Test that an invalid URL raises a ValueError"""
         with pytest.raises(ValueError):
             Dataverse(
-                server_url="not a url",
-                api_token="9eb39a88-ab0d-415d-80c2-32cbafdb5f6f",
+                server_url="not a url",  # type: ignore
+                api_token="9eb39a88-ab0d-415d-80c2-32cbafdb5f6f",  # type: ignore
             )
 
     @pytest.mark.unit
@@ -18,6 +18,6 @@ class TestDataverse:
         """Test that an invalid API token raises a ValueError"""
         with pytest.raises(ValueError):
             Dataverse(
-                server_url="http://localhost:8080",
-                api_token="not a uuid",
+                server_url="http://localhost:8080",  # type: ignore
+                api_token="not a uuid",  # type: ignore
             )


### PR DESCRIPTION
This PR introduces a new feature that allows users to specify the type of dataset when creating one. This functionality was first introduced in the Dataverse [6.4 release](). Users can now set the `dataset_type` attribute on a `Dataset` instance. Upon assignment, the validity of the dataset type is checked by calling the `api/datasets/datasetTypes` endpoint. 

Additionally, users can inspect the available dataset types by using the `list_dataset_types` method or the `dataset_types` method once connected to a `Dataverse` instance or class. While the `list_dataset_types` method is primarily intended for printing purposes, the `dataset_types` method provides a more detailed response from the `api/datasets/datasetTypes` endpoint, allowing for a more comprehensive access to the dataset type. 

Since this is a relatively new feature, version checks are performed upon assignment, and unsupported versions will simply skip the dataset type logic. Tests have been added to verify the functionality of this new feature.


### Example

```python
from easyDataverse import Dataverse

dataverse = Dataverse(...)
dataset = dataverse.create_dataset()

# List dataset type
demo_dv.list_dataset_types()

# Set the dataset type
dataset.dataset_type = "software"

# Upload and re-fetch to access the type
pid = dataset.upload("some_dv")

nu_dataset = demo_dv.load_dataset(pid)
print(nu_dataset.dataset_type)
```

For an interactive version, checkout this [Colab Notebook](https://colab.research.google.com/drive/1ebVjyMwOy6DOow7UlvQ-ky_GD6txeEXe?usp=sharing).

**Closes**

* #51 