### PR TITLE
Only generate add fun upon `multiple`

### DIFF
--- a/easyDataverse/classgen.py
+++ b/easyDataverse/classgen.py
@@ -122,10 +122,12 @@ def create_compound(
         # Set non-multiple compounds directly as default
         field_meta.default = None
         field_meta.default_factory = sub_cls
-
-    # Create add function
-    fun_name = f"add_{attribute_name}"
-    add_functions[fun_name] = generate_add_function(sub_cls, attribute_name, fun_name)
+    else:
+        # Create add function
+        fun_name = f"add_{attribute_name}"
+        add_functions[fun_name] = generate_add_function(
+            sub_cls, attribute_name, fun_name
+        )
 
     return (dtype, field_meta)
 


### PR DESCRIPTION
As mentioned in #53, compounds that aren’t set as `multiple` in the metadata block schema mistakenly receive an `add` function, causing the specific function to fail due to a non `List` type. This PR addresses this issue by only providing an `add` function once a compound is set to `multiple`.

See the following [Colab Notebook](https://colab.research.google.com/drive/1_DvAhG37ClhGRqeZSFBDo15iEvz_XBNc?usp=sharing) for verification.

* Closes #53 