### PR TITLE
Fix API Token type casting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{ include = "easyDataverse" }]
 [tool.poetry.dependencies]
 python = "^3.9"
 pydantic = "^2.7.1"
-pydataverse = "^0.3.1"
+pydataverse = "^0.3.4"
 pyaml = "^24.4.0"
 xmltodict = "^0.13.0"
 python-forge = "18.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{ include = "easyDataverse" }]
 [tool.poetry.dependencies]
 python = "^3.9"
 pydantic = "^2.7.1"
-pydataverse = "^0.3.4"
+pydataverse = "^0.3.1"
 pyaml = "^24.4.0"
 xmltodict = "^0.13.0"
 python-forge = "18.6.0"


### PR DESCRIPTION
As mentioned in #56, passing no API Token results in an invalid API Token error, which occurs due to a type conversion during connection. This PR addresses this issue. To verify its functionality, refer to this [Colab Notebook](https://colab.research.google.com/drive/1gU1YkatXQ3HD-nkiJEw3UFrrY5xuyHkz?usp=sharing).

* Closes #56 