### PR TITLE
Sanitize version num from string to int by removing non-numeric characters

### DIFF
--- a/easyDataverse/dataverse.py
+++ b/easyDataverse/dataverse.py
@@ -226,17 +226,34 @@ class Dataverse(BaseModel):
                 f"URL '{self.server_url}' is not a valid Dataverse installation. Couldn't find version info."
             )
 
-        major, minor, *_ = response.json()["data"]["version"].split(".")
-        
-        # Remove all the non-numeric parts from the version string to avoid having leading 'v' or other characters.
-        major = "".join(filter(str.isdigit, major))
-        minor = "".join(filter(str.isdigit, minor))
+        version = response.json()["data"]["version"]
+        major, minor = self._extract_major_minor(version)
 
         if int(major) >= 6:
             return True
         elif int(major) >= 5 and int(minor) >= 13:
             return True
 
+        return False
+
+    @staticmethod
+    def _extract_major_minor(version: str) -> Tuple[int, int]:
+        """Extracts the major and minor version numbers from a Dataverse version string."""
+        try:
+            major, minor, *_ = version.split(".")
+            major = "".join(filter(str.isdigit, major))
+            minor = "".join(filter(str.isdigit, minor))
+            return int(major), int(minor)
+        except ValueError:
+            raise ValueError(f"Version '{version}' is not a valid Dataverse version.")
+
+    @staticmethod
+    def _check_version(major: int, minor: int) -> bool:
+        """Checks if the version is compliant."""
+        if int(major) >= 6:
+            return True
+        elif int(major) >= 5 and int(minor) >= 13:
+            return True
         return False
 
     def _fetch_licenses(self) -> Dict[str, License]:

--- a/easyDataverse/dataverse.py
+++ b/easyDataverse/dataverse.py
@@ -227,6 +227,10 @@ class Dataverse(BaseModel):
             )
 
         major, minor, *_ = response.json()["data"]["version"].split(".")
+        
+        # Remove all the non-numeric parts from the version string to avoid having leading 'v' or other characters.
+        major = "".join(filter(str.isdigit, major))
+        minor = "".join(filter(str.isdigit, minor))
 
         if int(major) >= 6:
             return True

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -77,3 +77,8 @@ class TestConnection:
             Dataverse(server_url="https://dataverse.harvard.edu")
         except ValueError as e:
             AssertionError("Failed to parse numeric namespace: " + str(e))
+
+    @pytest.mark.integration
+    def test_version_borealis(self):
+        """Tests compatibility with BorealisData, which uses a different versioning scheme."""
+        Dataverse("https://borealisdata.ca/")

--- a/tests/unit/test_dataverse.py
+++ b/tests/unit/test_dataverse.py
@@ -21,3 +21,40 @@ class TestDataverse:
                 server_url="http://localhost:8080",
                 api_token="not a uuid",
             )
+
+    @pytest.mark.unit
+    def test_valid_versions(self):
+        """Test that the version is compliant"""
+        cases = [
+            "6.0",
+            "6.1",
+            "5.13",
+            "5.14",
+            "v6.0",
+            "v5.14",
+            "v5.13-beta",
+            "6.1.0",
+        ]
+
+        for version in cases:
+            major, minor = Dataverse._extract_major_minor(version)
+            assert Dataverse._check_version(major, minor)
+
+    @pytest.mark.unit
+    def test_invalid_version(self):
+        """Test that an invalid version raises a ValueError"""
+        with pytest.raises(ValueError):
+            Dataverse._extract_major_minor("not a version")
+
+    @pytest.mark.unit
+    def test_unsupported_version(self):
+        """Test that the version is compliant"""
+        cases = [
+            "4.0",
+            "4.1",
+            "5.12",
+            "5.11",
+        ]
+        for version in cases:
+            major, minor = Dataverse._extract_major_minor(version)
+            assert not Dataverse._check_version(major, minor)


### PR DESCRIPTION
I came across an issue when I was trying to initialize the `Dataverse` instance for [borealisdata.ca](https://borealisdata.ca/) (also (https://demo.borealisdata.ca/).

When I try to run this code:

```python
from easyDataverse import Dataverse
dataverse = Dataverse("https://borealisdata.ca/")
```
The error message:
```python
/dataverse.py:140, in Dataverse._connect(self)
    115 def _connect(self) -> None:
    116     """Connects to a Dataverse installation and adds all metadtablocks as classes.
...
--> 231 if int(major) >= 6:
    232     return True
    233 elif int(major) >= 5 and int(minor) >= 13:

ValueError: invalid literal for int() with base 10: 'v6'
```

The reason is that there is a leading `v` for the major version number in Borealis:
`{"status":"OK","data":{"version":"v6.4.1-SP","build":null}}`

This PR sanitizes the version number, ensuring the number can be changed from `str` to `int`, and can then perform the check.

Not sure this can be accepted! Because it's likely more a signle Dataverse instance issue!