### PR TITLE
Fix: `_get_version` in datasettype.py

### DIFF
--- a/easyDataverse/datasettype.py
+++ b/easyDataverse/datasettype.py
@@ -3,6 +3,7 @@ from urllib.parse import urljoin
 from pydantic import BaseModel, Field
 import httpx
 from pyDataverse.api import NativeApi
+from easyDataverse.utils import extract_major_minor
 
 
 class DatasetType(BaseModel):
@@ -60,5 +61,4 @@ class DatasetType(BaseModel):
         response = native_api.get_info_version()
         response.raise_for_status()
         version = response.json()["data"]["version"]
-        major, minor = version.split(".", 1)
-        return int(major), int(minor)
+        return extract_major_minor(version)

--- a/easyDataverse/dataverse.py
+++ b/easyDataverse/dataverse.py
@@ -9,6 +9,7 @@ from urllib import parse
 import httpx
 from easyDataverse.datasettype import DatasetType
 from easyDataverse.license import CustomLicense, License
+from easyDataverse.utils import extract_major_minor
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from anytree import Node, findall_by_attr
@@ -248,7 +249,7 @@ class Dataverse(BaseModel):
             )
 
         version = response.json()["data"]["version"]
-        major, minor = self._extract_major_minor(version)
+        major, minor = extract_major_minor(version)
 
         if int(major) >= 6:
             return True
@@ -256,17 +257,6 @@ class Dataverse(BaseModel):
             return True
 
         return False
-
-    @staticmethod
-    def _extract_major_minor(version: str) -> Tuple[int, int]:
-        """Extracts the major and minor version numbers from a Dataverse version string."""
-        try:
-            major, minor, *_ = version.split(".")
-            major = "".join(filter(str.isdigit, major))
-            minor = "".join(filter(str.isdigit, minor))
-            return int(major), int(minor)
-        except ValueError:
-            raise ValueError(f"Version '{version}' is not a valid Dataverse version.")
 
     @staticmethod
     def _check_version(major: int, minor: int) -> bool:

--- a/easyDataverse/utils.py
+++ b/easyDataverse/utils.py
@@ -1,6 +1,21 @@
 import yaml
+from typing import Tuple
 
 
 class YAMLDumper(yaml.Dumper):
     def increase_indent(self, flow=False, indentless=False):
         return super(YAMLDumper, self).increase_indent(flow, False)
+
+def extract_major_minor(version: str) -> Tuple[int, int]:
+    """Extracts the major and minor version numbers from a Dataverse version string.
+    
+    Args:
+        version: A string representing the Dataverse version, e.g., "6.4.0" or "v6.4.0".
+    """
+    try:
+        major, minor, *_ = version.split(".")
+        major = "".join(filter(str.isdigit, major))
+        minor = "".join(filter(str.isdigit, minor))
+        return int(major), int(minor)
+    except ValueError:
+        raise ValueError(f"Version '{version}' is not a valid Dataverse version.")

--- a/tests/unit/test_dataverse.py
+++ b/tests/unit/test_dataverse.py
@@ -1,6 +1,7 @@
 import pytest
 
 from easyDataverse.dataverse import Dataverse
+from easyDataverse.utils import extract_major_minor
 
 
 class TestDataverse:
@@ -37,14 +38,14 @@ class TestDataverse:
         ]
 
         for version in cases:
-            major, minor = Dataverse._extract_major_minor(version)
+            major, minor = extract_major_minor(version)
             assert Dataverse._check_version(major, minor)
 
     @pytest.mark.unit
     def test_invalid_version(self):
         """Test that an invalid version raises a ValueError"""
         with pytest.raises(ValueError):
-            Dataverse._extract_major_minor("not a version")
+            extract_major_minor("not a version")
 
     @pytest.mark.unit
     def test_unsupported_version(self):
@@ -56,5 +57,5 @@ class TestDataverse:
             "5.11",
         ]
         for version in cases:
-            major, minor = Dataverse._extract_major_minor(version)
+            major, minor = extract_major_minor(version)
             assert not Dataverse._check_version(major, minor)


### PR DESCRIPTION
This PR resolves a similar issue from #58 in the latest commit (1eccb26) of the `main` branch, where the `_get_version` in datasettype does not handle version numbers with non-numeric characters.

Since the `datasettype` and `dataverse` modules both check the Dataverse instance's version, this PR moved the `extract_major_minor` function to the `utils` module so that the two modules can jointly use it.