### PR TITLE
Update pyDataverse version and `upload` check

### DIFF
--- a/easyDataverse/dataset.py
+++ b/easyDataverse/dataset.py
@@ -304,7 +304,8 @@ class Dataset(BaseModel):
         if self.p_id is not None:
             raise ValueError(
                 "It seems like you are trying to upload a dataset that has already been uploaded. Please use the 'update' method instead.",
-                "If you are sure that you want to upload a new version of the dataset, please set the 'p_id' field to 'None'.",
+                "It seems like you are trying to upload a dataset that has already been uploaded. Please use the 'update' method instead.\n"
+                "If you are sure that you want to upload a new version of the dataset, please set the 'p_id' field to 'None'."
             )
 
         self._validate_required_fields()

--- a/easyDataverse/dataset.py
+++ b/easyDataverse/dataset.py
@@ -301,6 +301,12 @@ class Dataset(BaseModel):
             str: The identifier of the uploaded dataset.
         """
 
+        if self.p_id is not None:
+            raise ValueError(
+                "It seems like you are trying to upload a dataset that has already been uploaded. Please use the 'update' method instead.",
+                "If you are sure that you want to upload a new version of the dataset, please set the 'p_id' field to 'None'.",
+            )
+
         self._validate_required_fields()
 
         self.p_id = upload_to_dataverse(

--- a/easyDataverse/dataset.py
+++ b/easyDataverse/dataset.py
@@ -303,7 +303,6 @@ class Dataset(BaseModel):
 
         if self.p_id is not None:
             raise ValueError(
-                "It seems like you are trying to upload a dataset that has already been uploaded. Please use the 'update' method instead.",
                 "It seems like you are trying to upload a dataset that has already been uploaded. Please use the 'update' method instead.\n"
                 "If you are sure that you want to upload a new version of the dataset, please set the 'p_id' field to 'None'."
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{ include = "easyDataverse" }]
 [tool.poetry.dependencies]
 python = "^3.9"
 pydantic = "^2.7.1"
-pydataverse = "^0.3.4"
+pydataverse = "^0.3.5"
 pyaml = "^24.4.0"
 xmltodict = "^0.13.0"
 python-forge = "18.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{ include = "easyDataverse" }]
 [tool.poetry.dependencies]
 python = "^3.9"
 pydantic = "^2.7.1"
-pydataverse = "^0.3.1"
+pydataverse = "^0.3.4"
 pyaml = "^24.4.0"
 xmltodict = "^0.13.0"
 python-forge = "18.6.0"

--- a/tests/integration/test_dataset_creation.py
+++ b/tests/integration/test_dataset_creation.py
@@ -97,6 +97,43 @@ class TestDatasetCreation:
             )
 
     @pytest.mark.integration
+    def test_double_upload_raises_error(
+        self,
+        credentials,
+    ):
+        # Arrange
+        base_url, api_token = credentials
+        dataverse = Dataverse(
+            server_url=base_url,
+            api_token=api_token,
+        )
+
+        # Act
+        dataset = dataverse.create_dataset()
+
+        dataset.citation.title = "My dataset"
+        dataset.citation.subject = ["Other"]
+        dataset.citation.add_author(name="John Doe")
+        dataset.citation.add_ds_description(
+            value="This is a description of the dataset",
+            date="2024",
+        )
+        dataset.citation.add_dataset_contact(
+            name="John Doe",
+            email="john@doe.com",
+        )
+
+        dataset.add_directory(
+            dirpath="./tests/fixtures",
+            dv_dir="some/sub/dir",
+        )
+
+        dataset.upload(dataverse_name="root")
+
+        with pytest.raises(ValueError):
+            dataset.upload(dataverse_name="root")
+
+    @pytest.mark.integration
     def test_creation_and_upload_with_dataset_type(
         self,
         credentials,


### PR DESCRIPTION
This pull request adds a safeguard to prevent double uploads of the same dataset and updates the `pydataverse` dependency. The main changes include introducing a check in the `upload` method to raise an error if a dataset has already been uploaded, and adding a corresponding integration test to verify this behavior.

Dataset upload protection:

* Added a check in the `upload` method of `easyDataverse/dataset.py` to raise a `ValueError` if `p_id` is not `None`, preventing double uploads of the same dataset. The error message guides users to use the `update` method or reset `p_id` if needed.
* Added an integration test `test_double_upload_raises_error` in `tests/integration/test_dataset_creation.py` to ensure that attempting to upload a dataset twice raises a `ValueError`.

Dependency update:

* Updated the `pydataverse` dependency version from `0.3.1` to `0.3.4` in `pyproject.toml` for improved compatibility and bug fixes.