### PR TITLE
Exclude `None` values in custom license terms dump

### DIFF
--- a/easyDataverse/dataset.py
+++ b/easyDataverse/dataset.py
@@ -229,7 +229,11 @@ class Dataset(BaseModel):
         if isinstance(self.license, License):
             terms = {"license": self.license.name}
         elif isinstance(self.license, CustomLicense):
-            terms = self.license.model_dump(by_alias=True, exclude={"name"})
+            terms = self.license.model_dump(
+                by_alias=True,
+                exclude={"name"},
+                exclude_none=True,
+            )
         else:
             terms = {}
 


### PR DESCRIPTION
As pointed out in #46 by @bnavigator, this pull request introduces a minor enhancement to the serialization of license information within the `dataverse_dict` method. Specifically, when dumping a `CustomLicense` object, any fields with `None` values will now be excluded from the resulting output dictionary. 

Previously, when fields were set to `None`, Dataverse would issue warnings indicating that the files could not be processed (refer to https://github.com/gdcc/easyDataverse/issues/46#issuecomment-3083230634). By omitting these fields from the payload, the issue has been resolved.