### PR TITLE
Update dvuploader dependency to v0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dotted-dict = "1.1.3"
 rich = "^13.7.1"
 nob = "^0.8.2"
 nest-asyncio = "^1.6.0"
-dvuploader = "^0.3.0"
+dvuploader = "^0.3.1"
 email-validator = "^2.1.1"
 httpx = "^0.28"
 


### PR DESCRIPTION
This pull request updates the version of a dependency in the project. The change is straightforward and involves bumping the `dvuploader` package to the latest patch release.

* Updated the `dvuploader` dependency from version `^0.3.0` to `^0.3.1` in `pyproject.toml` to ensure the project uses the latest bug fixes and improvements.